### PR TITLE
render hundreds separately from minutes/seconds; add performance test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
 
 # For information on the generic Dart part of this file, see the

--- a/test_driver/perf.dart
+++ b/test_driver/perf.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:stopwatch/main.dart' as app;
+
+void main() {
+  // The Flutter Driver extension adds just enough instrumentation
+  // for the test script to interact with the app.
+  enableFlutterDriverExtension();
+  app.main();
+}

--- a/test_driver/perf_test.dart
+++ b/test_driver/perf_test.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+// Run this test using:
+//
+// flutter drive --profile test_driver/perf.dart
+void main() {
+  group('performance', () {
+    FlutterDriver driver;
+
+    setUp(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    tearDown(() async {
+      await driver.close();
+    });
+
+    test('timer performs well', () async {
+      await new Future.delayed(const Duration(seconds: 2));
+      await driver.tap(find.text('start'));
+      final Timeline timeline = await driver.traceAction(() async {
+        await new Future.delayed(const Duration(seconds: 5));
+      });
+      await driver.tap(find.text('stop'));
+      final TimelineSummary summary = new TimelineSummary.summarize(timeline);
+
+      // Average amount of time it takes the framework to build a frame (mostly Dart framework code).
+      print('Avg. build: ${summary.computeAverageFrameBuildTimeMillis()} milliseconds');
+
+      // Average amount of time it take to make pixels (mostly C++ engine code).
+      print('Avg. rasterize: ${summary.computeAverageFrameRasterizerTimeMillis()} milliseconds');
+    });
+  });
+}


### PR DESCRIPTION
- Avoid reformatting and re-rasterizing minutes and seconds on every tick. This shaves off ~30% on the framework side of things according to my testing.
- Add a FlutterDriver test that measures the performance of the app.

WARNING: I didn't really test the app thoroughly; things might have broken; also there are a couple of anti-patterns in there, such as the global static list of timer listeners.
